### PR TITLE
added dependency on zlib dev libs

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -28,6 +28,7 @@ jenkins_vagrant = ::File.join(jenkins_data[:home], ".vagrant.d")
 [ "build-essential",
   "libxml2-dev",
   "libxslt-dev",
+  "zlib1g-dev",
   "ruby1.9.1-full",
   "git-core" ].each do |pkg|
   package pkg


### PR DESCRIPTION
the vagrant-berkshelf plugin install is super sad without zlib-dev in place.  test-kitchen doesn't catch this because zlib-dev is baked into opscode's bento boxes (since opscode is sane).  not everyone is sane.
